### PR TITLE
Changed reference to Atom to be generic

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -141,7 +141,7 @@ tip of the branch.
 
   `git checkout master`
 
-  Switch back and forth between the two with atom open.
+  Switch back and forth between the two with your text editor open.
 
 - Switch back to master and make a change to branching.txt
   On master, change the first line


### PR DESCRIPTION
The Atom text editor was being referenced; that could be a tad confusing to folks who don't know what Atom is (or just have Sublime installed). Just modified it to be more generic.
